### PR TITLE
DTAB-182: Thinkific Integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,24 @@ jobs:
         run: |
           cv en thinkific
 
+      - name: Setup Test DB
+        run: echo "CREATE DATABASE civicrm_test;" | mysql -u root --password=root --host=mysql
+
+      - name: Update civicrm.settings.php
+        run: |
+          FILE_PATH="$GITHUB_WORKSPACE/site/web/sites/default/civicrm.settings.php"
+          INSERT_LINE="\$GLOBALS['_CV']['TEST_DB_DSN'] = 'mysql://root:root@mysql:3306/civicrm_test?new_link=true';"
+          TMP_FILE=$(mktemp)
+          while IFS= read -r line
+          do
+              echo "$line" >> "$TMP_FILE"
+              if [ "$line" = "<?php" ]; then
+                  echo "$INSERT_LINE" >> "$TMP_FILE"
+              fi
+          done < "$FILE_PATH"
+          mv "$TMP_FILE" "$FILE_PATH"
+          echo "File modified successfully."
+
       - name: Run phpunit tests
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/thinkific
         run: phpunit9

--- a/CRM/Thinkific/Form/Settings.php
+++ b/CRM/Thinkific/Form/Settings.php
@@ -2,7 +2,6 @@
 
 use CRM_Thinkific_ExtensionUtil as E;
 use Civi\Thinkific\SettingsManager;
-use Civi\Thinkific\Service\ApiClient;
 use GuzzleHttp\Exception\BadResponseException;
 
 /**
@@ -34,7 +33,8 @@ class CRM_Thinkific_Form_Settings extends CRM_Core_Form {
     $values = $this->exportValues();
 
     try {
-      $client = new ApiClient();
+      /** @var Civi\Thinkific\Service\ApiClient $client */
+      $client = Civi::service('service.thinkific.api_client');
       $headers = [
         'X-Auth-API-Key' => $values[SettingsManager::API_KEY],
         'X-Auth-Subdomain' => $values[SettingsManager::SUBDOMAIN],
@@ -98,7 +98,6 @@ class CRM_Thinkific_Form_Settings extends CRM_Core_Form {
     // items don't have labels.  We'll identify renderable by filtering on
     // the 'label'.
     $elementNames = [];
-    /** @phpstan-ignore property.notFound */
     foreach ($this->_elements as $element) {
       /** @var HTML_QuickForm_element $element */
       $label = $element->getLabel();

--- a/Civi/Thinkific/ContactCustomFieldsManager.php
+++ b/Civi/Thinkific/ContactCustomFieldsManager.php
@@ -3,6 +3,7 @@
 namespace Civi\Thinkific;
 
 class ContactCustomFieldsManager {
+  const CUSTOM_GROUP = 'Thinkific_sync_data';
   const USER_FIELD = 'Thinkific_user_ID';
   const SYNC_STATUS_FIELD = 'Sync_status';
   const SYNC_DATE_FIELD = 'Last_synced_date';

--- a/Civi/Thinkific/EventCustomFieldsManager.php
+++ b/Civi/Thinkific/EventCustomFieldsManager.php
@@ -2,10 +2,11 @@
 
 namespace Civi\Thinkific;
 
-class CustomFieldsManager {
+class EventCustomFieldsManager {
+  const CUSTOM_GROUP = 'Sync_Event_to_Thinkific';
   const STATUS_FIELD = 'Participant_Status_to_Enroll_in_Thinkific_Course';
   const ROLES_FIELD = 'Participant_Roles_to_Enroll_in_Thinkific_Course';
   const SYNC_FIELD = 'Sync_to_Thinkific';
-  const CODE_FIELD = 'Thinkific_Course_Code';
+  const ID_FIELD = 'Thinkific_Course_Id';
 
 }

--- a/Civi/Thinkific/Hook/BuildForm/Event.php
+++ b/Civi/Thinkific/Hook/BuildForm/Event.php
@@ -4,12 +4,11 @@ namespace Civi\Thinkific\Hook\BuildForm;
 
 class Event {
 
-  public function __construct(private \CRM_Core_Form $form) {
+  public function __construct() {
   }
 
   public function run(): void {
     \CRM_Core_Resources::singleton()->addScriptFile('io.compuco.thinkific', 'js/modifyEventForm.js');
-    \Civi::resources()->addVars('thinkific', ['action' => $this->form->_action]);
   }
 
   public static function shouldRun(string $formName, \CRM_Core_Form $form): bool {

--- a/Civi/Thinkific/Hook/Container/ServiceContainer.php
+++ b/Civi/Thinkific/Hook/Container/ServiceContainer.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Civi\Thinkific\Hook\Container;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class ServiceContainer {
+
+  /**
+   * @var \Symfony\Component\DependencyInjection\ContainerBuilder
+   */
+  private ContainerBuilder $container;
+
+  /**
+   * ServiceContainer constructor.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+   */
+  public function __construct(ContainerBuilder $container) {
+    $this->container = $container;
+  }
+
+  /**
+   * Registers services to container.
+   */
+  public function register(): void {
+    $this->container->setDefinition('service.thinkific.api_client', new Definition(
+      \Civi\Thinkific\Service\ApiClient::class
+    ))->setAutowired(TRUE)->setPublic(TRUE);
+    $this->container->setDefinition('service.thinkific.participant_manager', new Definition(
+      \Civi\Thinkific\Service\ParticipantManager::class
+    ))->setAutowired(TRUE)->setPublic(TRUE);
+    $this->container->setDefinition('service.thinkific.user_handler', new Definition(
+      \Civi\Thinkific\Service\UserHandler::class
+    ))->setAutowired(TRUE)->setPublic(TRUE);
+    $this->container->setDefinition('service.thinkific.enrollment_handler', new Definition(
+      \Civi\Thinkific\Service\EnrollmentHandler::class
+    ))->setAutowired(TRUE)->setPublic(TRUE);
+
+    $this->container->setAlias('Civi\Thinkific\Service\ApiClient', 'service.thinkific.api_client');
+    $this->container->setAlias('Civi\Thinkific\Service\ParticipantManager', 'service.thinkific.participant_manager');
+    $this->container->setAlias('Civi\Thinkific\Service\UserHandler', 'service.thinkific.user_handler');
+    $this->container->setAlias('Civi\Thinkific\Service\EnrollmentHandler', 'service.thinkific.enrollment_handler');
+  }
+
+}

--- a/Civi/Thinkific/Hook/FieldOptions/EventCreation.php
+++ b/Civi/Thinkific/Hook/FieldOptions/EventCreation.php
@@ -2,7 +2,7 @@
 
 namespace Civi\Thinkific\Hook\FieldOptions;
 
-use Civi\Thinkific\CustomFieldsManager;
+use Civi\Thinkific\EventCustomFieldsManager;
 
 class EventCreation {
 
@@ -24,7 +24,7 @@ class EventCreation {
 
   public function run(): void {
     $thinkificFields = self::getThinkificFields();
-    if (array_search($this->field, $thinkificFields) === CustomFieldsManager::ROLES_FIELD) {
+    if (array_search($this->field, $thinkificFields) === EventCustomFieldsManager::ROLES_FIELD) {
       $this->fillRolesFieldOptions();
       return;
     }
@@ -54,7 +54,7 @@ class EventCreation {
       'checkPermissions' => FALSE,
       'select' => ['CONCAT("custom_", id) AS identifier', 'name'],
       'where' => [
-        ['name', 'IN', [CustomFieldsManager::ROLES_FIELD, CustomFieldsManager::STATUS_FIELD]],
+        ['name', 'IN', [EventCustomFieldsManager::ROLES_FIELD, EventCustomFieldsManager::STATUS_FIELD]],
       ],
     ])->getArrayCopy();
 

--- a/Civi/Thinkific/Hook/Post/Participant.php
+++ b/Civi/Thinkific/Hook/Post/Participant.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Civi\Thinkific\Hook\Post;
+
+use Civi\Thinkific\EventCustomFieldsManager;
+
+class Participant {
+
+  /**
+   * @var array
+   * @phpstan-ignore missingType.iterableValue
+   */
+  private static array $processedParticipants = [];
+
+  public function __construct(private int $participantId, private \CRM_Event_DAO_Participant $participant) {
+  }
+
+  public function run(): void {
+    self::$processedParticipants[$this->participantId] = 1;
+    /** @var array<string, string|int|int[]> $eventData */
+    $eventData = civicrm_api4('Event', 'get', [
+      'checkPermissions' => FALSE,
+      'select' => [EventCustomFieldsManager::CUSTOM_GROUP . '.*'],
+      'where' => [['id', '=', $this->participant->event_id]],
+    ])->getArrayCopy()[0] ?? [];
+
+    if (empty($eventData)) {
+      return;
+    }
+    if (empty($eventData[EventCustomFieldsManager::CUSTOM_GROUP . '.' . EventCustomFieldsManager::SYNC_FIELD][0])) {
+      return;
+    }
+    if (empty($eventData[EventCustomFieldsManager::CUSTOM_GROUP . '.' . EventCustomFieldsManager::ID_FIELD])) {
+      return;
+    }
+
+    /** @var \Civi\Thinkific\Service\ParticipantManager $participantManager */
+    $participantManager = \Civi::service('service.thinkific.participant_manager');
+    /** @var string[] $eventStatuses */
+    $eventStatuses = $eventData[EventCustomFieldsManager::CUSTOM_GROUP . '.' . EventCustomFieldsManager::STATUS_FIELD];
+    $courseId = (int) $eventData[EventCustomFieldsManager::CUSTOM_GROUP . '.' . EventCustomFieldsManager::ID_FIELD];
+    if (!empty($eventStatuses) && !in_array($this->participant->status_id, $eventStatuses)) {
+      $participantManager->removeParticipant($this->participant, $courseId);
+      return;
+    }
+    /** @var string $participantRoles */
+    $participantRoles = $this->participant->role_id;
+    /** @var string[] $eventRoles */
+    $eventRoles = $eventData[EventCustomFieldsManager::CUSTOM_GROUP . '.' . EventCustomFieldsManager::ROLES_FIELD];
+    if (!empty($eventRoles) && empty(array_intersect(explode(\CRM_Core_DAO::VALUE_SEPARATOR, $participantRoles), $eventRoles))) {
+      $participantManager->removeParticipant($this->participant, $courseId);
+      return;
+    }
+
+    $participantManager->addParticipant($this->participant, $courseId);
+  }
+
+  /**
+   * @param string $op
+   * @param string $objectName
+   * @param int $objectId
+   * @param object|array<string,mixed> $objectRef
+   *
+   * @return bool
+   */
+  public static function shouldRun(string $op, string $objectName, int $objectId, $objectRef): bool {
+    if (!in_array($op, ['create', 'edit']) || $objectName !== 'Participant' || !$objectRef instanceof \CRM_Event_DAO_Participant || isset(self::$processedParticipants[$objectId])) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+}

--- a/Civi/Thinkific/ParticipantCustomFieldsManager.php
+++ b/Civi/Thinkific/ParticipantCustomFieldsManager.php
@@ -3,6 +3,7 @@
 namespace Civi\Thinkific;
 
 class ParticipantCustomFieldsManager {
+  const CUSTOM_GROUP = 'Thinkific_sync';
   const ENROLLMENT_FIELD = 'Thinkific_enrolment_ID';
   const SYNC_STATUS_FIELD = 'Sync_status';
   const SYNC_DATE_FIELD = 'Last_synced_date';

--- a/Civi/Thinkific/Service/EnrollmentHandler.php
+++ b/Civi/Thinkific/Service/EnrollmentHandler.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Civi\Thinkific\Service;
+
+use Civi\Thinkific\ParticipantCustomFieldsManager;
+use Psr\Http\Message\ResponseInterface;
+
+class EnrollmentHandler {
+
+  public function __construct(private ApiClient $apiClient) {
+  }
+
+  public function enroll(int $userId, int $courseId, int $participantId): void {
+    $currentEnrollment = $this->getCurrentEnrollment($userId, $courseId);
+    if (empty($currentEnrollment->id)) {
+      $url = 'enrollments';
+      $enrollmentData = ['course_id' => $courseId, 'user_id' => $userId, 'activated_at' => date('Y-m-d\TH:i:s\Z')];
+
+      try {
+        $enrollmentResponse = $this->apiClient->request('POST', $url, [], $enrollmentData);
+        $enrollmentResponseContent = $enrollmentResponse->getBody()->getContents();
+        if (!empty($enrollmentResponseContent)) {
+          /** @var \stdClass $newEnrollment */
+          $newEnrollment = json_decode($enrollmentResponseContent);
+          $this->updateParticipant($enrollmentResponse, $participantId, $newEnrollment);
+        }
+      }
+      catch (\GuzzleHttp\Exception\ClientException $e) {
+        $this->updateParticipant($e->getResponse(), $participantId, new \stdClass());
+        throw $e;
+      }
+    }
+  }
+
+  public function unEnroll(int $userId, int $courseId, int $participantId): void {
+    $currentEnrollment = $this->getCurrentEnrollment($userId, $courseId);
+    if (empty($currentEnrollment->id)) {
+      return;
+    }
+
+    $url = 'enrollments/' . $currentEnrollment->id;
+    $enrollmentData = ['expiry_date' => date('Y-m-d\TH:i:s\Z')];
+    try {
+      $unEnrollResponse = $this->apiClient->request('PUT', $url, [], $enrollmentData);
+      $this->updateParticipant($unEnrollResponse, $participantId, $currentEnrollment);
+    }
+    catch (\GuzzleHttp\Exception\ClientException $e) {
+      $this->updateParticipant($e->getResponse(), $participantId, $currentEnrollment);
+      throw $e;
+    }
+  }
+
+  public function getCurrentEnrollment(int $userId, int $courseId): \stdClass {
+    $url = '/enrollments?query[user_id]=' . $userId . '&query[course_id]=' . $courseId . '&query[expired]=0';
+    $currentEnrollment = new \stdClass();
+
+    try {
+      $enrollmentResponse = $this->apiClient->request('GET', $url);
+      $enrollment         = json_decode($enrollmentResponse->getBody()->getContents());
+      if ($enrollment instanceof \stdClass && !empty($enrollment->items)) {
+        $currentEnrollment = $enrollment->items[0];
+      }
+    }
+    catch (\Throwable $e) {
+    }
+
+    return $currentEnrollment;
+  }
+
+  public function updateParticipant(ResponseInterface $response, int $participantId, \stdClass $enrollment): void {
+    $statusCode = $response->getStatusCode();
+    civicrm_api4('Participant', 'update', [
+      'values' => [
+        ParticipantCustomFieldsManager::CUSTOM_GROUP . '.' . ParticipantCustomFieldsManager::ENROLLMENT_FIELD  => $enrollment->id ?? NULL,
+        ParticipantCustomFieldsManager::CUSTOM_GROUP . '.' . ParticipantCustomFieldsManager::RESPONSE_FIELD    => !empty($enrollment->id) ? serialize($enrollment) : $statusCode,
+        ParticipantCustomFieldsManager::CUSTOM_GROUP . '.' . ParticipantCustomFieldsManager::SYNC_STATUS_FIELD => $statusCode >= 200 && $statusCode <= 299 ? '1' : '0',
+        ParticipantCustomFieldsManager::CUSTOM_GROUP . '.' . ParticipantCustomFieldsManager::SYNC_DATE_FIELD   => date('Y-m-d H:i:s'),
+      ],
+      'where' => [
+        ['id', '=', $participantId],
+      ],
+      'checkPermissions' => FALSE,
+    ]);
+  }
+
+}

--- a/Civi/Thinkific/Service/ParticipantManager.php
+++ b/Civi/Thinkific/Service/ParticipantManager.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Civi\Thinkific\Service;
+
+use Civi\Thinkific\Utils\Webform;
+
+class ParticipantManager {
+
+  public function __construct(private UserHandler $userHandler, private EnrollmentHandler $enrollmentHandler) {
+  }
+
+  public function addParticipant(\CRM_Event_DAO_Participant $participant, int $courseId): void {
+    try {
+      $participantStatusId = (int) $participant->status_id;
+      $participantId = (int) $participant->id;
+      $participantStatus = \CRM_Event_PseudoConstant::participantStatus($participantStatusId);
+      $thinkificUserId   = $this->userHandler->getThinkificUserIdForParticipant($participant);
+      $this->enrollmentHandler->enroll($thinkificUserId, $courseId, $participantId);
+    }
+    catch (\Throwable $e) {
+      \Civi::log()->error('Participant enrollment error for participant ' . $participant->id . ' :: ' . $e->getMessage());
+      $this->displayError();
+    }
+  }
+
+  public function removeParticipant(\CRM_Event_DAO_Participant $participant, int $courseId): void {
+    try {
+      $thinkificUserId = $this->userHandler->getThinkificUserIdForParticipant($participant);
+      $participantId = (int) $participant->id;
+      $this->enrollmentHandler->unEnroll($thinkificUserId, $courseId, $participantId);
+    }
+    catch (\Throwable $e) {
+      \Civi::log()->error('Participant un-enrollment error for participant ' . $participant->id . ' :: ' . $e->getMessage());
+      $this->displayError();
+    }
+  }
+
+  private function displayError(): void {
+    $msg = 'Your purchase or registration was successful but an error occurred with your course enrolment. Please contact the administrator to resolve this.';
+    if (Webform::isWebformSubmission()) {
+      /** @phpstan-ignore function.notFound */
+      drupal_set_message($msg, 'error');
+    }
+    else {
+      \CRM_Core_Session::setStatus($msg, 'LMS Integration:', 'error');
+    }
+  }
+
+}

--- a/Civi/Thinkific/Service/UserHandler.php
+++ b/Civi/Thinkific/Service/UserHandler.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Civi\Thinkific\Service;
+
+use Civi\Thinkific\ContactCustomFieldsManager;
+use Psr\Http\Message\ResponseInterface;
+
+class UserHandler {
+
+  public function __construct(private ApiClient $apiClient) {
+  }
+
+  public function getThinkificUserIdForParticipant(\CRM_Event_DAO_Participant $participant): int {
+    $existingThinkificUserId = $this->getContactsThinkificId((int) $participant->contact_id);
+    $updateUser = TRUE;
+    $contactId = (int) $participant->contact_id;
+
+    if ($existingThinkificUserId === 0) {
+      $existingThinkificUserId = $this->getExistingThinkificUserIdByEmail((string) \CRM_Contact_BAO_Contact::getPrimaryEmail($contactId));
+      if ($existingThinkificUserId > 0) {
+        $externalId = $this->getContactIdFromThinkific($existingThinkificUserId);
+        if ($externalId > 0 && $externalId !== (int) $participant->contact_id) {
+          $updateUser = FALSE;
+        }
+      }
+    }
+    if ($existingThinkificUserId > 0) {
+      if ($updateUser) {
+        $this->updateThinkificUser((int) $participant->contact_id, $existingThinkificUserId);
+      }
+      return $existingThinkificUserId;
+    }
+
+    return $this->createNewThinkificUser((int) $participant->contact_id);
+  }
+
+  public function getContactsThinkificId(int $contactId): int {
+    /** @var array<string, string|int> $contactThinkificData */
+    $contactThinkificData = civicrm_api4('Contact', 'get', [
+      'checkPermissions' => FALSE,
+      'select' => [ContactCustomFieldsManager::CUSTOM_GROUP . '.*'],
+      'where' => [['id', '=', $contactId]],
+    ])->getArrayCopy()[0] ?? [];
+
+    if (empty($contactThinkificData)
+      || empty($contactThinkificData[ContactCustomFieldsManager::CUSTOM_GROUP . '.' . ContactCustomFieldsManager::USER_FIELD])) {
+      return 0;
+    }
+    try {
+      $url = 'users/' . $contactThinkificData[ContactCustomFieldsManager::CUSTOM_GROUP . '.' . ContactCustomFieldsManager::USER_FIELD];
+      $existingUserResponse = $this->apiClient->request('GET', $url);
+      /** @var \stdClass $existingUserObject */
+      $existingUserObject = json_decode($existingUserResponse->getBody()->getContents());
+      if (!empty($existingUserObject->id)) {
+        return (int) $contactThinkificData[ContactCustomFieldsManager::CUSTOM_GROUP . '.' . ContactCustomFieldsManager::USER_FIELD];
+      }
+    }
+    catch (\Throwable $e) {
+    }
+
+    return 0;
+  }
+
+  public function getExistingThinkificUserIdByEmail(string $email): int {
+    $existingUserID = 0;
+    if ($email === '') {
+      return $existingUserID;
+    }
+
+    $url = 'users/?query[email]=' . $email;
+    try {
+      $existingUserResponse = $this->apiClient->request('GET', $url);
+      /** @var \stdClass $existingUserObject */
+      $existingUserObject = json_decode($existingUserResponse->getBody()->getContents());
+      if (!empty($existingUserObject->items) && !empty($existingUserObject->items[0]) && $existingUserObject->items[0] instanceof \stdClass) {
+        $existingUserID = (int) ($existingUserObject->items[0]->id ?? 0);
+      }
+    }
+    catch (\Throwable $e) {
+    }
+
+    return $existingUserID;
+  }
+
+  public function updateThinkificUser(int $contactId, int $thinkificUserId): void {
+    $contactData = $this->getContactData($contactId);
+    if (empty($contactData)) {
+      throw new \InvalidArgumentException('Contact does not have all required information!');
+    }
+
+    $url = 'users/' . $thinkificUserId;
+    $userData = [
+      'first_name' => $contactData['first_name'],
+      'last_name' => $contactData['last_name'],
+      'company' => (string) $contactData['employer_id.display_name'],
+      'external_id' => $contactId,
+    ];
+    try {
+      $updateUserResponse = $this->apiClient->request('PUT', $url, [], $userData);
+      $this->updateContact($updateUserResponse, $contactId, $thinkificUserId);
+    }
+    catch (\GuzzleHttp\Exception\ClientException $e) {
+      $this->updateContact($e->getResponse(), $contactId, $thinkificUserId);
+      throw $e;
+    }
+  }
+
+  public function createNewThinkificUser(int $contactId): int {
+    $email = (string) \CRM_Contact_BAO_Contact::getPrimaryEmail($contactId);
+    $contactData = $this->getContactData($contactId);
+    if ($email === '' || empty($contactData)) {
+      throw new \InvalidArgumentException('Contact does not have all required information!');
+    }
+
+    $url = 'users';
+    $userData = [
+      'first_name' => $contactData['first_name'],
+      'last_name' => $contactData['last_name'],
+      'email' => $email,
+      'company' => (string) $contactData['employer_id.display_name'],
+      'external_id' => $contactId,
+    ];
+    try {
+      $createUserResponse = $this->apiClient->request('POST', $url, [], $userData);
+      /** @var \stdClass $newUser */
+      $newUser = json_decode($createUserResponse->getBody()->getContents());
+      $thinkificUserId = $newUser->id ?? 0;
+      $this->updateContact($createUserResponse, $contactId, $thinkificUserId, $newUser);
+
+      return $thinkificUserId;
+    }
+    catch (\GuzzleHttp\Exception\ClientException $e) {
+      $this->updateContact($e->getResponse(), $contactId, NULL);
+      throw $e;
+    }
+  }
+
+  public function updateContact(ResponseInterface $response, int $contactId, ?int $thinkificUserId, ?\stdClass $user = NULL): void {
+    $statusCode = $response->getStatusCode();
+    $response = !empty($user) ? $user : $response->getBody()->getContents();
+    civicrm_api4('Contact', 'update', [
+      'values'           => [
+        ContactCustomFieldsManager::CUSTOM_GROUP . '.' . ContactCustomFieldsManager::USER_FIELD        => $thinkificUserId,
+        ContactCustomFieldsManager::CUSTOM_GROUP . '.' . ContactCustomFieldsManager::RESPONSE_FIELD    => !empty($response) ? serialize($response) : $statusCode,
+        ContactCustomFieldsManager::CUSTOM_GROUP . '.' . ContactCustomFieldsManager::SYNC_STATUS_FIELD => $statusCode >= 200 && $statusCode <= 299 ? '1' : '0',
+        ContactCustomFieldsManager::CUSTOM_GROUP . '.' . ContactCustomFieldsManager::SYNC_DATE_FIELD   => date('Y-m-d H:i:s'),
+      ],
+      'where'            => [
+        ['id', '=', $contactId],
+      ],
+      'checkPermissions' => FALSE,
+    ]);
+  }
+
+  public function getContactIdFromThinkific(int $thinkificUserId): int {
+    $url = 'users/' . $thinkificUserId . '/authentications/SSO';
+    $externalUserResponse = $this->apiClient->request('GET', $url,);
+    $externalUserData = json_decode($externalUserResponse->getBody()->getContents());
+
+    return $externalUserData instanceof \stdClass && $externalUserData->external_id ? $externalUserData->external_id : 0;
+  }
+
+  /**
+   * @param int $contactId
+   *
+   * @return array<string, string|int>
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\NotImplementedException
+   */
+  public function getContactData(int $contactId): array {
+    /** @var array<string, string|int> $contactData */
+    $contactData = civicrm_api4('Contact', 'get', [
+      'checkPermissions' => FALSE,
+      'select' => ['*', 'employer_id.display_name'],
+      'where' => [['id', '=', $contactId]],
+    ])->getArrayCopy()[0] ?? [];
+
+    return $contactData;
+  }
+
+}

--- a/Civi/Thinkific/Utils/Webform.php
+++ b/Civi/Thinkific/Utils/Webform.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Civi\Thinkific\Utils;
+
+class Webform {
+
+  public static function isWebformSubmission(): bool {
+    /** @var string $formID */
+    $formID = \CRM_Utils_Request::retrieve('form_id', 'String', NULL, FALSE, '');
+
+    return str_contains($formID, 'webform_client_form_');
+  }
+
+}

--- a/js/modifyEventForm.js
+++ b/js/modifyEventForm.js
@@ -2,16 +2,19 @@ CRM.$(function ($) {
 
   (function() {
    observeCustomFieldsAreDisplayed();
+   if (document.querySelector('#customData_Event')) {
+     (new window.MutationObserver(function () {
+       observeCustomFieldsAreDisplayed();
+     })).observe(document.querySelector('#customData_Event'), {
+       attributes: true
+     });
+   }
   })();
 
   function observeCustomFieldsAreDisplayed() {
     const observer = new window.MutationObserver(function () {
       if ($('.custom-group-Sync_Event_to_Thinkific').length) {
         observer.disconnect();
-
-        if (CRM.vars.thinkific.action === 1) {
-          $('.custom-group-Sync_Event_to_Thinkific input.crm-form-checkbox').attr('checked', true);
-        }
 
         toggleCustomGroupFields();
         $('.custom-group-Sync_Event_to_Thinkific input.crm-form-checkbox').on("change", function () {
@@ -30,7 +33,7 @@ CRM.$(function ($) {
     let syncCheckbox = $('.custom-group-Sync_Event_to_Thinkific input.crm-form-checkbox');
 
     let fields = [
-      $("input[data-crm-custom='Sync_Event_to_Thinkific:Thinkific_Course_Code']"),
+      $("input[data-crm-custom='Sync_Event_to_Thinkific:Thinkific_Course_Id']"),
       $("select[data-crm-custom='Sync_Event_to_Thinkific:Participant_Status_to_Enroll_in_Thinkific_Course']"),
       $("select[data-crm-custom='Sync_Event_to_Thinkific:Participant_Roles_to_Enroll_in_Thinkific_Course']"),
     ];

--- a/managed/CustomGroupContact_Thinkific_sync_data.mgd.php
+++ b/managed/CustomGroupContact_Thinkific_sync_data.mgd.php
@@ -16,7 +16,7 @@ return [
     'params' => [
       'version' => 4,
       'values' => [
-        'name' => 'Thinkific_sync_data',
+        'name' => ContactCustomFieldsManager::CUSTOM_GROUP,
         'title' => 'Thinkific sync data',
         'extends' => 'Contact',
         'extends_entity_column_value' => NULL,
@@ -40,6 +40,83 @@ return [
     ],
   ],
   [
+    'name' => 'OptionGroup_Thinkific_Sync_Status',
+    'entity' => 'OptionGroup',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Thinkific_Sync_Status',
+        'title' => 'Thinkific sync :: Sync status',
+        'description' => NULL,
+        'data_type' => 'String',
+        'is_reserved' => FALSE,
+        'is_active' => TRUE,
+        'is_locked' => FALSE,
+        'option_value_fields' => [
+          'name',
+          'label',
+          'description',
+        ],
+      ],
+    ],
+  ],
+  [
+    'name' => 'OptionGroup_Thinkific_Sync_Status_OptionValue_Successful',
+    'entity' => 'OptionValue',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'Thinkific_Sync_Status',
+        'label' => 'Successful',
+        'value' => '1',
+        'name' => 'Successful',
+        'grouping' => NULL,
+        'filter' => 0,
+        'is_default' => FALSE,
+        'description' => NULL,
+        'is_optgroup' => FALSE,
+        'is_reserved' => FALSE,
+        'is_active' => TRUE,
+        'icon' => NULL,
+        'color' => NULL,
+        'component_id' => NULL,
+        'domain_id' => NULL,
+        'visibility_id' => NULL,
+      ],
+    ],
+  ],
+  [
+    'name' => 'OptionGroup_Thinkific_Sync_Status_OptionValue_Failed',
+    'entity' => 'OptionValue',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'Thinkific_Sync_Status',
+        'label' => 'Failed',
+        'value' => '0',
+        'name' => 'Failed',
+        'grouping' => NULL,
+        'filter' => 0,
+        'is_default' => FALSE,
+        'description' => NULL,
+        'is_optgroup' => FALSE,
+        'is_reserved' => FALSE,
+        'is_active' => TRUE,
+        'icon' => NULL,
+        'color' => NULL,
+        'component_id' => NULL,
+        'domain_id' => NULL,
+        'visibility_id' => NULL,
+      ],
+    ],
+  ],
+  [
     'name' => 'CustomGroup_Thinkific_Sync_Data_CustomField_Thinkific_User_ID',
     'entity' => 'CustomField',
     'cleanup' => 'unused',
@@ -47,7 +124,7 @@ return [
     'params' => [
       'version' => 4,
       'values' => [
-        'custom_group_id.name' => 'Thinkific_sync_data',
+        'custom_group_id.name' => ContactCustomFieldsManager::CUSTOM_GROUP,
         'name' => ContactCustomFieldsManager::USER_FIELD,
         'label' => 'Thinkific user ID',
         'data_type' => 'String',
@@ -62,7 +139,7 @@ return [
         'attributes' => NULL,
         'javascript' => NULL,
         'is_active' => TRUE,
-        'is_view' => FALSE,
+        'is_view' => TRUE,
         'options_per_line' => NULL,
         'text_length' => 255,
         'start_date_years' => NULL,
@@ -86,7 +163,7 @@ return [
     'params' => [
       'version' => 4,
       'values' => [
-        'custom_group_id.name' => 'Thinkific_sync_data',
+        'custom_group_id.name' => ContactCustomFieldsManager::CUSTOM_GROUP,
         'name' => ContactCustomFieldsManager::SYNC_STATUS_FIELD,
         'label' => 'Sync status',
         'data_type' => 'String',
@@ -126,7 +203,7 @@ return [
     'params' => [
       'version' => 4,
       'values' => [
-        'custom_group_id.name' => 'Thinkific_sync_data',
+        'custom_group_id.name' => ContactCustomFieldsManager::CUSTOM_GROUP,
         'name' => ContactCustomFieldsManager::SYNC_DATE_FIELD,
         'label' => 'Last synced date',
         'data_type' => 'Date',
@@ -146,7 +223,7 @@ return [
         'text_length' => 255,
         'start_date_years' => NULL,
         'end_date_years' => NULL,
-        'date_format' => 'dd-mm-yyyy',
+        'date_format' => 'dd-mm-yy',
         'time_format' => 2,
         'note_columns' => 60,
         'note_rows' => 4,
@@ -165,7 +242,7 @@ return [
     'params' => [
       'version' => 4,
       'values' => [
-        'custom_group_id.name' => 'Thinkific_sync_data',
+        'custom_group_id.name' => ContactCustomFieldsManager::CUSTOM_GROUP,
         'name' => ContactCustomFieldsManager::RESPONSE_FIELD,
         'label' => 'Last API response',
         'data_type' => 'Memo',

--- a/managed/CustomGroupParticipant_Thinkific_sync.mgd.php
+++ b/managed/CustomGroupParticipant_Thinkific_sync.mgd.php
@@ -16,7 +16,7 @@ return [
     'params' => [
       'version' => 4,
       'values' => [
-        'name' => 'Thinkific_sync',
+        'name' => ParticipantCustomFieldsManager::CUSTOM_GROUP,
         'title' => 'Thinkific sync',
         'extends' => 'Participant',
         'extends_entity_column_value' => NULL,
@@ -47,7 +47,7 @@ return [
     'params' => [
       'version' => 4,
       'values' => [
-        'custom_group_id.name' => 'Thinkific_sync',
+        'custom_group_id.name' => ParticipantCustomFieldsManager::CUSTOM_GROUP,
         'name' => ParticipantCustomFieldsManager::ENROLLMENT_FIELD,
         'label' => 'Thinkific enrolment ID',
         'data_type' => 'String',
@@ -62,7 +62,7 @@ return [
         'attributes' => NULL,
         'javascript' => NULL,
         'is_active' => TRUE,
-        'is_view' => FALSE,
+        'is_view' => TRUE,
         'options_per_line' => NULL,
         'text_length' => 255,
         'start_date_years' => NULL,
@@ -79,83 +79,6 @@ return [
     ],
   ],
   [
-    'name' => 'OptionGroup_Thinkific_Sync_Status',
-    'entity' => 'OptionGroup',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'name' => 'Thinkific_Sync_Status',
-        'title' => 'Thinkific sync :: Sync status',
-        'description' => NULL,
-        'data_type' => 'String',
-        'is_reserved' => FALSE,
-        'is_active' => TRUE,
-        'is_locked' => FALSE,
-        'option_value_fields' => [
-          'name',
-          'label',
-          'description',
-        ],
-      ],
-    ],
-  ],
-  [
-    'name' => 'OptionGroup_Thinkific_Sync_Status_OptionValue_Successful',
-    'entity' => 'OptionValue',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'option_group_id.name' => 'Thinkific_Sync_Status',
-        'label' => 'Successful',
-        'value' => '1',
-        'name' => 'Successful',
-        'grouping' => NULL,
-        'filter' => 0,
-        'is_default' => FALSE,
-        'description' => NULL,
-        'is_optgroup' => FALSE,
-        'is_reserved' => FALSE,
-        'is_active' => TRUE,
-        'icon' => NULL,
-        'color' => NULL,
-        'component_id' => NULL,
-        'domain_id' => NULL,
-        'visibility_id' => NULL,
-      ],
-    ],
-  ],
-  [
-    'name' => 'OptionGroup_Thinkific_Sync_Status_OptionValue_Failed',
-    'entity' => 'OptionValue',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'option_group_id.name' => 'Thinkific_Sync_Status',
-        'label' => 'Failed',
-        'value' => '0',
-        'name' => 'Failed',
-        'grouping' => NULL,
-        'filter' => 0,
-        'is_default' => FALSE,
-        'description' => NULL,
-        'is_optgroup' => FALSE,
-        'is_reserved' => FALSE,
-        'is_active' => TRUE,
-        'icon' => NULL,
-        'color' => NULL,
-        'component_id' => NULL,
-        'domain_id' => NULL,
-        'visibility_id' => NULL,
-      ],
-    ],
-  ],
-  [
     'name' => 'CustomGroup_Thinkific_sync_CustomField_Sync_Status',
     'entity' => 'CustomField',
     'cleanup' => 'unused',
@@ -163,7 +86,7 @@ return [
     'params' => [
       'version' => 4,
       'values' => [
-        'custom_group_id.name' => 'Thinkific_sync',
+        'custom_group_id.name' => ParticipantCustomFieldsManager::CUSTOM_GROUP,
         'name' => ParticipantCustomFieldsManager::SYNC_STATUS_FIELD,
         'label' => 'Sync status',
         'data_type' => 'String',
@@ -203,7 +126,7 @@ return [
     'params' => [
       'version' => 4,
       'values' => [
-        'custom_group_id.name' => 'Thinkific_sync',
+        'custom_group_id.name' => ParticipantCustomFieldsManager::CUSTOM_GROUP,
         'name' => ParticipantCustomFieldsManager::SYNC_DATE_FIELD,
         'label' => 'Last synced date',
         'data_type' => 'Date',
@@ -223,7 +146,7 @@ return [
         'text_length' => 255,
         'start_date_years' => NULL,
         'end_date_years' => NULL,
-        'date_format' => 'dd-mm-yyyy',
+        'date_format' => 'dd-mm-yy',
         'time_format' => 2,
         'note_columns' => 60,
         'note_rows' => 4,
@@ -242,7 +165,7 @@ return [
     'params' => [
       'version' => 4,
       'values' => [
-        'custom_group_id.name' => 'Thinkific_sync',
+        'custom_group_id.name' => ParticipantCustomFieldsManager::CUSTOM_GROUP,
         'name' => ParticipantCustomFieldsManager::RESPONSE_FIELD,
         'label' => 'Last API response',
         'data_type' => 'Memo',

--- a/managed/CustomGroup_Sync_Event_to_thinkific.mgd.php
+++ b/managed/CustomGroup_Sync_Event_to_thinkific.mgd.php
@@ -5,7 +5,7 @@
  * Exported Custom group and fields for Sync Event to Thinkific.
  */
 
-use Civi\Thinkific\CustomFieldsManager;
+use Civi\Thinkific\EventCustomFieldsManager;
 
 $mgd = [
   [
@@ -16,7 +16,7 @@ $mgd = [
     'params' => [
       'version' => 4,
       'values' => [
-        'name' => 'Sync_Event_to_Thinkific',
+        'name' => EventCustomFieldsManager::CUSTOM_GROUP,
         'title' => 'Sync Event to Thinkific',
         'extends' => 'Event',
         'extends_entity_column_value' => NULL,
@@ -97,12 +97,12 @@ $mgd = [
     'params' => [
       'version' => 4,
       'values' => [
-        'custom_group_id.name' => 'Sync_Event_to_Thinkific',
-        'name' => CustomFieldsManager::SYNC_FIELD,
+        'custom_group_id.name' => EventCustomFieldsManager::CUSTOM_GROUP,
+        'name' => EventCustomFieldsManager::SYNC_FIELD,
         'label' => 'Sync event to Thinkific',
         'data_type' => 'String',
         'html_type' => 'CheckBox',
-        'default_value' => 1,
+        'default_value' => NULL,
         'is_required' => FALSE,
         'is_searchable' => FALSE,
         'is_search_range' => FALSE,
@@ -130,16 +130,16 @@ $mgd = [
     ],
   ],
   [
-    'name' => 'CustomGroup_Sync_Event_to_Thinkific_CustomField_Thinkific_Course_Code',
+    'name' => 'CustomGroup_Sync_Event_to_Thinkific_CustomField_Thinkific_Course_Id',
     'entity' => 'CustomField',
     'cleanup' => 'unused',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
       'values' => [
-        'custom_group_id.name' => 'Sync_Event_to_Thinkific',
-        'name' => CustomFieldsManager::CODE_FIELD,
-        'label' => 'Thinkific course code',
+        'custom_group_id.name' => EventCustomFieldsManager::CUSTOM_GROUP,
+        'name' => EventCustomFieldsManager::ID_FIELD,
+        'label' => 'Thinkific course ID',
         'data_type' => 'String',
         'html_type' => 'Text',
         'default_value' => NULL,
@@ -161,7 +161,7 @@ $mgd = [
         'time_format' => NULL,
         'note_columns' => 60,
         'note_rows' => 4,
-        'column_name' => 'thinkific_course_code',
+        'column_name' => 'thinkific_course_id',
         'serialize' => 0,
         'filter' => NULL,
         'in_selector' => FALSE,
@@ -176,8 +176,8 @@ $mgd = [
     'params' => [
       'version' => 4,
       'values' => [
-        'custom_group_id.name' => 'Sync_Event_to_Thinkific',
-        'name' => CustomFieldsManager::ROLES_FIELD,
+        'custom_group_id.name' => EventCustomFieldsManager::CUSTOM_GROUP,
+        'name' => EventCustomFieldsManager::ROLES_FIELD,
         'label' => 'Participant roles to enrol in Thinkific course',
         'data_type' => 'String',
         'html_type' => 'Select',
@@ -215,8 +215,8 @@ $mgd = [
     'params' => [
       'version' => 4,
       'values' => [
-        'custom_group_id.name' => 'Sync_Event_to_Thinkific',
-        'name' => CustomFieldsManager::STATUS_FIELD,
+        'custom_group_id.name' => EventCustomFieldsManager::CUSTOM_GROUP,
+        'name' => EventCustomFieldsManager::STATUS_FIELD,
         'label' => 'Participant status to enrol in Thinkific course',
         'data_type' => 'String',
         'html_type' => 'Select',

--- a/tests/phpunit/Civi/Thinkific/Service/EnrollmentHandlerTest.php
+++ b/tests/phpunit/Civi/Thinkific/Service/EnrollmentHandlerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Civi\Thinkific\Service\EnrollmentHandler;
+use Civi\Thinkific\Service\ApiClient;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * @group headless
+ */
+class EnrollmentHandlerTest extends BaseHeadlessTest {
+
+  public function testEnrollmentIsCreatedOnlyIfItDoesNotExist(): void {
+    $courseId = 123;
+    $userId = 456;
+    $participantId = 789;
+
+    $mockApiClient = $this->getMockBuilder(ApiClient::class)->disableOriginalConstructor()->getMock();
+    $mockApiClient->expects($this->once())
+      ->method('request')
+      ->with(
+        'POST',
+        'enrollments',
+        [],
+        ['course_id' => $courseId, 'user_id' => $userId, 'activated_at' => date('Y-m-d\TH:i:s\Z')],
+      )
+      ->willReturn(new Response());
+
+    $mockEnrollmentHandler = $this->getMockBuilder(EnrollmentHandler::class)
+      ->onlyMethods(['getCurrentEnrollment', 'updateParticipant'])
+      ->setConstructorArgs([$mockApiClient])
+      ->getMock();
+    $mockEnrollmentHandler->expects($this->once())->method('getCurrentEnrollment')->willReturn(new stdClass());
+
+    $mockEnrollmentHandler->enroll($userId, $courseId, $participantId, FALSE);
+  }
+
+  public function testEnrollmentIsNotCreatedIfItExists(): void {
+    $courseId = 123;
+    $userId = 456;
+    $participantId = 789;
+    $currentEnrollment = new stdClass();
+    $currentEnrollment->id = 10;
+
+    $mockApiClient = $this->getMockBuilder(ApiClient::class)->disableOriginalConstructor()->getMock();
+    $mockApiClient->expects($this->never())->method('request');
+
+    $mockEnrollmentHandler = $this
+      ->getMockBuilder(EnrollmentHandler::class)
+      ->onlyMethods(['getCurrentEnrollment', 'updateParticipant'])
+      ->setConstructorArgs([$mockApiClient])
+      ->getMock();
+    $mockEnrollmentHandler->expects($this->once())->method('getCurrentEnrollment')->willReturn($currentEnrollment);
+
+    $mockEnrollmentHandler->enroll($userId, $courseId, $participantId, FALSE);
+  }
+
+  public function testUnEnrollmentHappensOnlyIfItExists(): void {
+    $courseId = 123;
+    $userId = 456;
+    $participantId = 789;
+
+    $mockApiClient = $this
+      ->getMockBuilder(ApiClient::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $mockApiClient->expects($this->never())->method('request');
+
+    $mockEnrollmentHandler = $this
+      ->getMockBuilder(EnrollmentHandler::class)
+      ->onlyMethods(['getCurrentEnrollment'])
+      ->setConstructorArgs([$mockApiClient])
+      ->getMock();
+    $mockEnrollmentHandler->expects($this->once())->method('getCurrentEnrollment')->willReturn(new stdClass());
+
+    $mockEnrollmentHandler->unEnroll($userId, $courseId, $participantId);
+  }
+
+}

--- a/tests/phpunit/Civi/Thinkific/Service/UserHandlerTest.php
+++ b/tests/phpunit/Civi/Thinkific/Service/UserHandlerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use Civi\Thinkific\Service\UserHandler;
+use Civi\Thinkific\Service\ApiClient;
+use Civi\Thinkific\Test\Fabricator\ContactFabricator;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * @group headless
+ */
+class UserHandlerTest extends BaseHeadlessTest {
+
+  public function testNewUserIsCreatedOnlyIfItDoesNotExist(): void {
+    $participant = new CRM_Event_DAO_Participant();
+    $firstName = 'test';
+    $lastName = 'test';
+    $email = 'test@test.com';
+    $contact = ContactFabricator::fabricateWithEmail(['first_name' => $firstName, 'last_name' => $lastName], $email);
+    $participant->contact_id = $contact['id'];
+
+    $mockApiClient = $this->getMockBuilder(ApiClient::class)->disableOriginalConstructor()->getMock();
+    $mockApiClient->expects($this->once())->method('request')->with(
+        'POST',
+        'users',
+        [],
+        ['first_name' => $firstName, 'last_name' => $lastName, 'email' => $email, 'company' => '', 'external_id' => $contact['id']],
+      )
+      ->willReturn(new Response());
+
+    $mockUserHandler = $this
+      ->getMockBuilder(UserHandler::class)
+      ->onlyMethods(['getContactsThinkificId', 'getExistingThinkificUserIdByEmail', 'getContactData', 'updateContact', 'updateThinkificUser'])
+      ->setConstructorArgs([$mockApiClient])
+      ->getMock();
+    $mockUserHandler->expects($this->once())
+      ->method('getContactsThinkificId')
+      ->willReturn(0);
+    $mockUserHandler->expects($this->once())
+      ->method('getExistingThinkificUserIdByEmail')
+      ->willReturn(0);
+    $mockUserHandler->expects($this->once())
+      ->method('getContactData')
+      ->willReturn(['first_name' => $firstName, 'last_name' => $lastName, 'employer_id.display_name' => NULL]);
+    $mockUserHandler->expects($this->once())
+      ->method('updateContact');
+    $mockUserHandler->expects($this->never())
+      ->method('updateThinkificUser');
+
+    $mockUserHandler->getThinkificUserIdForParticipant($participant);
+  }
+
+  public function testNewUserIsOnlyUpdatedIfItExists(): void {
+    $participant = new CRM_Event_DAO_Participant();
+    $firstName = 'test';
+    $lastName = 'test';
+    $email = 'test@test.com';
+    $thinkificUserId = 10;
+    $contact = ContactFabricator::fabricateWithEmail(
+      [
+        'first_name' => $firstName,
+        'last_name' => $lastName,
+      ],
+      $email
+    );
+    $participant->contact_id = $contact['id'];
+
+    $mockApiClient = $this->getMockBuilder(ApiClient::class)->disableOriginalConstructor()->getMock();
+    $mockApiClient->expects($this->once())
+      ->method('request')
+      ->with(
+        'PUT',
+        'users/' . $thinkificUserId,
+        [],
+        ['first_name' => $firstName, 'last_name' => $lastName, 'company' => '', 'external_id' => $contact['id']],
+      )
+      ->willReturn(new Response());
+
+    $mockUserHandler = $this
+      ->getMockBuilder(UserHandler::class)
+      ->onlyMethods(['getContactsThinkificId', 'createNewThinkificUser'])
+      ->setConstructorArgs([$mockApiClient])
+      ->getMock();
+    $mockUserHandler->expects($this->once())
+      ->method('getContactsThinkificId')
+      ->willReturn($thinkificUserId);
+    $mockUserHandler->expects($this->never())
+      ->method('createNewThinkificUser');
+
+    $mockUserHandler->getThinkificUserIdForParticipant($participant);
+  }
+
+}

--- a/tests/phpunit/Civi/Thinkific/Test/Fabricator/AbstractBaseFabricator.php
+++ b/tests/phpunit/Civi/Thinkific/Test/Fabricator/AbstractBaseFabricator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Civi\Thinkific\Test\Fabricator;
+
+class AbstractBaseFabricator {
+
+  /**
+   * Name of the entity to be fabricated.
+   *
+   * @var string
+   */
+  protected static $entityName;
+
+  /**
+   * List of default parameters to use on fabrication of entities.
+   *
+   * @var array
+   */
+  protected static $defaultParams = [];
+
+  /**
+   * Fabricates an instance of the entity with the given parameters.
+   *
+   * @param array $params
+   *
+   * @return mixed
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Exception
+   */
+  public static function fabricate(array $params = []) {
+    if (empty(static::$entityName)) {
+      throw new \Exception('Entity name cannot be empty!');
+    }
+
+    $params = array_merge(static::$defaultParams, $params);
+    $result = civicrm_api3(static::$entityName, 'create', $params);
+
+    return array_shift($result['values']);
+  }
+
+}

--- a/tests/phpunit/Civi/Thinkific/Test/Fabricator/ContactFabricator.php
+++ b/tests/phpunit/Civi/Thinkific/Test/Fabricator/ContactFabricator.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Civi\Thinkific\Test\Fabricator;
+
+class ContactFabricator extends AbstractBaseFabricator {
+
+  /**
+   * Entity's name.
+   *
+   * @var string
+   */
+  protected static $entityName = 'Contact';
+
+  /**
+   * Array if default parameters to be used to create a contact.
+   *
+   * @var array
+   */
+  protected static $defaultParams = [
+    'contact_type' => 'Individual',
+    'first_name'   => 'Test',
+    'last_name'    => 'Test',
+    'sequential'   => 1,
+  ];
+
+  /**
+   * Fabricates a contact with the given parameters.
+   *
+   * @param array $params
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function fabricate(array $params = []) {
+    $params = array_merge(static::$defaultParams, $params);
+    $params['display_name'] = "{$params['first_name']} {$params['last_name']}";
+
+    return parent::fabricate($params);
+  }
+
+  /**
+   * Fabricates a contact with an e-mail address.
+   *
+   * @param array $params
+   * @param string $email
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function fabricateWithEmail($params = [], $email = 'iamthe@batman.com') {
+    $contact = self::fabricate($params);
+
+    civicrm_api3('Email', 'create', [
+      'email' => $email,
+      'contact_id' => $contact['id'],
+      'is_primary' => 1,
+    ]);
+
+    return $contact;
+  }
+
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -2,8 +2,13 @@
 
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
+
+define('CIVICRM_CONTAINER_CACHE', 'never');
+define('CIVICRM_TEST', 1);
+putenv('CIVICRM_UF=' . ($_ENV['CIVICRM_UF'] = 'UnitTests'));
+
 // phpcs:disable
-eval(cv('php:boot --level=classloader', 'phpcode'));
+eval(cv('php:boot --level=settings', 'phpcode'));
 // phpcs:enable
 // Allow autoloading of PHPUnit helper classes in this extension.
 $loader = new \Composer\Autoload\ClassLoader();


### PR DESCRIPTION
## Overview
This PR adds integration between thinkific and civicrm events. Whenever an event in civicrm is configured and connected with thinkific course by adding a thinkific course id and a participant registers for the event either through webform, event registration form or admin form, an enrollment is created in thinkific for the course that was connected to the event.

## Technical Details
This PR adds a post civicrm hook that runs on the updation/creation of participant entity. Once the hook is fired it first checks if the event's thinkific sync has been enabled and a thinkific course id has been attached to the event then the hook starts the integration process.

The integration process first tries to identify the thinkifc user id first through contact record in civicrm then querying thinkific by email but if it does not found any of these then it creates a new user in thinkific. Once the user is found then it checks of the participant status and roles matches the event's thinkifc configuration if it does matches then it creates a new enrollment otherwise it expires any existing enrollments.