### PR TITLE
DTAB-228: User Flow Improvements

### DIFF
--- a/Civi/Thinkific/Hook/PostProcess/ParticipantRegistration.php
+++ b/Civi/Thinkific/Hook/PostProcess/ParticipantRegistration.php
@@ -7,7 +7,7 @@ use Civi\Thinkific\Utils\ErrorHandler;
 class ParticipantRegistration {
 
   public function run(): void {
-    ErrorHandler::displayCiviError();
+    ErrorHandler::displayCiviError(ErrorHandler::LMS_SYNC_ERROR_MESSAGE);
   }
 
   public static function shouldRun(string $formName, \CRM_Core_Form $form): bool {

--- a/Civi/Thinkific/Hook/Pre/Participant.php
+++ b/Civi/Thinkific/Hook/Pre/Participant.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Civi\Thinkific\Hook\Pre;
+
+use Civi\Thinkific\EventCustomFieldsManager;
+use Civi\Thinkific\Utils\ErrorHandler;
+
+class Participant {
+
+  /**
+   * Participant constructor.
+   *
+   * @param array<string,string|int> $participant
+   */
+  public function __construct(private array $participant) {
+  }
+
+  public function run(): void {
+    /** @var array<string, string|int|int[]> $eventData */
+    $eventData = civicrm_api4('Event', 'get', [
+      'checkPermissions' => FALSE,
+      'select' => [EventCustomFieldsManager::CUSTOM_GROUP . '.*'],
+      'where' => [['id', '=', $this->participant['event_id'] ?? 0]],
+    ])->getArrayCopy()[0] ?? [];
+
+    if (empty($eventData) ||
+      empty($eventData[EventCustomFieldsManager::CUSTOM_GROUP . '.' . EventCustomFieldsManager::SYNC_FIELD][0]) ||
+      empty($eventData[EventCustomFieldsManager::CUSTOM_GROUP . '.' . EventCustomFieldsManager::ID_FIELD])
+    ) {
+      return;
+    }
+
+    $this->validateParticipantEmail();
+  }
+
+  /**
+   * @param string $op
+   * @param string $objectName
+   * @param object|array<string,mixed> $params
+   *
+   * @return bool
+   */
+  public static function shouldRun(string $op, string $objectName, $params): bool {
+    if (!in_array($op, ['create', 'edit']) || $objectName !== 'Participant' || !is_array($params)) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  private function validateParticipantEmail(): void {
+    /** @var \Civi\Thinkific\Service\UserHandler $userHandler */
+    $userHandler = \Civi::service('service.thinkific.user_handler');
+    $contactId = (int) ($this->participant['contact_id'] ?? 0);
+    $thinkificUser = $userHandler->getExistingThinkificUserByEmail(
+      (string) \CRM_Contact_BAO_Contact::getPrimaryEmail($contactId)
+    );
+    try {
+      $userHandler->validateExternalSource($thinkificUser->external_source ?? '', $contactId);
+    }
+    catch (\InvalidArgumentException $e) {
+      ErrorHandler::displayError(ErrorHandler::EMAIL_EXIST_ERROR_MESSAGE);
+      \CRM_Utils_System::redirect(\CRM_Utils_System::refererPath());
+    }
+  }
+
+}

--- a/Civi/Thinkific/Service/ParticipantManager.php
+++ b/Civi/Thinkific/Service/ParticipantManager.php
@@ -36,7 +36,7 @@ class ParticipantManager {
 
   private function displayError(): void {
     if (Webform::isWebformSubmission()) {
-      ErrorHandler::displayWebformError();
+      ErrorHandler::displayWebformError(ErrorHandler::LMS_SYNC_ERROR_MESSAGE);
     }
     else {
       \Civi::$statics[\CRM_Thinkific_ExtensionUtil::LONG_NAME]['participantSynError'] = TRUE;

--- a/Civi/Thinkific/Service/UserHandler.php
+++ b/Civi/Thinkific/Service/UserHandler.php
@@ -7,31 +7,29 @@ use Psr\Http\Message\ResponseInterface;
 
 class UserHandler {
 
+  const EXTERNAL_SOURCE_PREFIX = 'civi_';
+
   public function __construct(private ApiClient $apiClient) {
   }
 
   public function getThinkificUserIdForParticipant(\CRM_Event_DAO_Participant $participant): int {
     $existingThinkificUserId = $this->getContactsThinkificId((int) $participant->contact_id);
-    $updateUser = TRUE;
     $contactId = (int) $participant->contact_id;
 
     if ($existingThinkificUserId === 0) {
-      $existingThinkificUserId = $this->getExistingThinkificUserIdByEmail((string) \CRM_Contact_BAO_Contact::getPrimaryEmail($contactId));
-      if ($existingThinkificUserId > 0) {
-        $externalId = $this->getContactIdFromThinkific($existingThinkificUserId);
-        if ($externalId > 0 && $externalId !== (int) $participant->contact_id) {
-          $updateUser = FALSE;
-        }
+      $existingThinkificUser = $this->getExistingThinkificUserByEmail((string) \CRM_Contact_BAO_Contact::getPrimaryEmail($contactId));
+      if (!empty($existingThinkificUser->id)) {
+        $this->validateExternalSource($existingThinkificUser->external_source ?? '', $contactId);
+        $existingThinkificUserId = $existingThinkificUser->id;
       }
     }
     if ($existingThinkificUserId > 0) {
-      if ($updateUser) {
-        $this->updateThinkificUser((int) $participant->contact_id, $existingThinkificUserId);
-      }
+      $this->updateThinkificUser($contactId, $existingThinkificUserId);
+
       return $existingThinkificUserId;
     }
 
-    return $this->createNewThinkificUser((int) $participant->contact_id);
+    return $this->createNewThinkificUser($contactId);
   }
 
   public function getContactsThinkificId(int $contactId): int {
@@ -61,10 +59,10 @@ class UserHandler {
     return 0;
   }
 
-  public function getExistingThinkificUserIdByEmail(string $email): int {
-    $existingUserID = 0;
+  public function getExistingThinkificUserByEmail(string $email): \stdClass {
+    $existingUser = new \stdClass();
     if ($email === '') {
-      return $existingUserID;
+      return $existingUser;
     }
 
     $url = 'users/?query[email]=' . $email;
@@ -73,13 +71,13 @@ class UserHandler {
       /** @var \stdClass $existingUserObject */
       $existingUserObject = json_decode($existingUserResponse->getBody()->getContents());
       if (!empty($existingUserObject->items) && !empty($existingUserObject->items[0]) && $existingUserObject->items[0] instanceof \stdClass) {
-        $existingUserID = (int) ($existingUserObject->items[0]->id ?? 0);
+        $existingUser = $existingUserObject->items[0];
       }
     }
     catch (\Throwable $e) {
     }
 
-    return $existingUserID;
+    return $existingUser;
   }
 
   public function updateThinkificUser(int $contactId, int $thinkificUserId): void {
@@ -93,7 +91,7 @@ class UserHandler {
       'first_name' => $contactData['first_name'],
       'last_name' => $contactData['last_name'],
       'company' => (string) $contactData['employer_id.display_name'],
-      'external_id' => $contactId,
+      'external_source' => self::EXTERNAL_SOURCE_PREFIX . $contactId,
     ];
     try {
       $updateUserResponse = $this->apiClient->request('PUT', $url, [], $userData);
@@ -118,7 +116,7 @@ class UserHandler {
       'last_name' => $contactData['last_name'],
       'email' => $email,
       'company' => (string) $contactData['employer_id.display_name'],
-      'external_id' => $contactId,
+      'external_source' => self::EXTERNAL_SOURCE_PREFIX . $contactId,
     ];
     try {
       $createUserResponse = $this->apiClient->request('POST', $url, [], $userData);
@@ -152,14 +150,6 @@ class UserHandler {
     ]);
   }
 
-  public function getContactIdFromThinkific(int $thinkificUserId): int {
-    $url = 'users/' . $thinkificUserId . '/authentications/SSO';
-    $externalUserResponse = $this->apiClient->request('GET', $url,);
-    $externalUserData = json_decode($externalUserResponse->getBody()->getContents());
-
-    return $externalUserData instanceof \stdClass && $externalUserData->external_id ? $externalUserData->external_id : 0;
-  }
-
   /**
    * @param int $contactId
    *
@@ -176,6 +166,14 @@ class UserHandler {
     ])->getArrayCopy()[0] ?? [];
 
     return $contactData;
+  }
+
+  public function validateExternalSource(string $source, int $contactId): void {
+    preg_match('/civi_(\d+)/', $source, $matches);
+
+    if (!empty($matches[1]) && (int) $matches[1] !== $contactId) {
+      throw new \InvalidArgumentException('Email already exist in thinkific and its linked to another contact');
+    }
   }
 
 }

--- a/Civi/Thinkific/Utils/ErrorHandler.php
+++ b/Civi/Thinkific/Utils/ErrorHandler.php
@@ -4,18 +4,28 @@ namespace Civi\Thinkific\Utils;
 
 class ErrorHandler {
 
-  const ERROR_MESSAGE = 'Your purchase or registration was successful but an error occurred with your course enrolment. Please contact the administrator to resolve this.';
+  const LMS_SYNC_ERROR_MESSAGE = 'Your purchase or registration was successful but an error occurred with your course enrolment. Please contact the administrator to resolve this.';
+  const EMAIL_EXIST_ERROR_MESSAGE = 'This email address is currently associated with a different account in the Learning Management System. Please select another or contact your administrator.';
 
-  public static function displayWebformError(): void {
+  public static function displayError(string $message): void {
+    if (Webform::isWebformSubmission()) {
+      self::displayWebformError($message);
+    }
+    else {
+      self::displayCiviError($message);
+    }
+  }
+
+  public static function displayWebformError(string $message): void {
     /** @phpstan-ignore function.notFound */
     drupal_get_messages();
     /** @phpstan-ignore function.notFound */
-    drupal_set_message(self::ERROR_MESSAGE, 'error');
+    drupal_set_message($message, 'error');
   }
 
-  public static function displayCiviError(): void {
+  public static function displayCiviError(string $message): void {
     \CRM_Core_Session::singleton()->getStatus(TRUE);
-    \CRM_Core_Session::singleton()->setStatus(self::ERROR_MESSAGE, 'LMS Integration:', 'error');
+    \CRM_Core_Session::singleton()->setStatus($message, 'LMS Integration:', 'error');
   }
 
 }

--- a/tests/phpunit/Civi/Thinkific/Service/UserHandlerTest.php
+++ b/tests/phpunit/Civi/Thinkific/Service/UserHandlerTest.php
@@ -23,21 +23,21 @@ class UserHandlerTest extends BaseHeadlessTest {
         'POST',
         'users',
         [],
-        ['first_name' => $firstName, 'last_name' => $lastName, 'email' => $email, 'company' => '', 'external_id' => $contact['id']],
+        ['first_name' => $firstName, 'last_name' => $lastName, 'email' => $email, 'company' => '', 'external_source' => UserHandler::EXTERNAL_SOURCE_PREFIX . $contact['id']],
       )
       ->willReturn(new Response());
 
     $mockUserHandler = $this
       ->getMockBuilder(UserHandler::class)
-      ->onlyMethods(['getContactsThinkificId', 'getExistingThinkificUserIdByEmail', 'getContactData', 'updateContact', 'updateThinkificUser'])
+      ->onlyMethods(['getContactsThinkificId', 'getExistingThinkificUserByEmail', 'getContactData', 'updateContact', 'updateThinkificUser'])
       ->setConstructorArgs([$mockApiClient])
       ->getMock();
     $mockUserHandler->expects($this->once())
       ->method('getContactsThinkificId')
       ->willReturn(0);
     $mockUserHandler->expects($this->once())
-      ->method('getExistingThinkificUserIdByEmail')
-      ->willReturn(0);
+      ->method('getExistingThinkificUserByEmail')
+      ->willReturn(new stdClass());
     $mockUserHandler->expects($this->once())
       ->method('getContactData')
       ->willReturn(['first_name' => $firstName, 'last_name' => $lastName, 'employer_id.display_name' => NULL]);
@@ -71,7 +71,7 @@ class UserHandlerTest extends BaseHeadlessTest {
         'PUT',
         'users/' . $thinkificUserId,
         [],
-        ['first_name' => $firstName, 'last_name' => $lastName, 'company' => '', 'external_id' => $contact['id']],
+        ['first_name' => $firstName, 'last_name' => $lastName, 'company' => '', 'external_source' => UserHandler::EXTERNAL_SOURCE_PREFIX . $contact['id']],
       )
       ->willReturn(new Response());
 

--- a/thinkific.php
+++ b/thinkific.php
@@ -5,7 +5,8 @@ require_once 'thinkific.civix.php';
 use CRM_Thinkific_ExtensionUtil as E;
 use Civi\Thinkific\Hook\BuildForm\Event;
 use Civi\Thinkific\Hook\FieldOptions\EventCreation;
-use Civi\Thinkific\Hook\Post\Participant;
+use Civi\Thinkific\Hook\Post\Participant as PostParticipant;
+use Civi\Thinkific\Hook\Pre\Participant as PreParticipant;
 use Civi\Thinkific\Hook\PostProcess\ParticipantRegistration;
 
 /**
@@ -76,8 +77,8 @@ function thinkific_civicrm_buildForm(string $formName, CRM_Core_Form $form) {
 
 function thinkific_civicrm_post(string $op, string $objectName, int $objectId, &$objectRef) {
   $hooks = [];
-  if (Participant::shouldRun($op, $objectName, $objectId, $objectRef)) {
-    $hooks[] = new Participant($objectId, $objectRef);
+  if (PostParticipant::shouldRun($op, $objectName, $objectId, $objectRef)) {
+    $hooks[] = new PostParticipant($objectId, $objectRef);
   }
 
   array_walk($hooks, function ($hook) {
@@ -106,6 +107,17 @@ function thinkific_civicrm_postProcess($formName, $form): void {
   $hooks = [];
   if (ParticipantRegistration::shouldRun($formName, $form)) {
     $hooks[] = new ParticipantRegistration();
+  }
+
+  array_walk($hooks, function ($hook) {
+    $hook->run();
+  });
+}
+
+function thinkific_civicrm_pre(string $op, string $objectName, ?int $objectId, &$params) {
+  $hooks = [];
+  if (PreParticipant::shouldRun($op, $objectName, $params)) {
+    $hooks[] = new PreParticipant($params);
   }
 
   array_walk($hooks, function ($hook) {


### PR DESCRIPTION
## Overview
This PR is an enhancement to the handling of overall user flow. It mainly does following things

Use external source instead of external id field to store civicrm contact id in thinkific
Restrict usage of same email for two different civicrm contacts such that if a contact or anonymous user is registering for an event by using an email which is already there in thinkific and its linked to a different contact then user is presented with a following error and event registration is halted.
<img width="1792" alt="Screenshot 2025-06-11 at 10 21 20 PM" src="https://github.com/user-attachments/assets/e516a5f7-ec98-4915-baf0-3c6fc76adafd" />


