### PR TITLE
DTAB-263: Check For Spaces In Field Values

### DIFF
--- a/CRM/Thinkific/Form/Settings.php
+++ b/CRM/Thinkific/Form/Settings.php
@@ -109,4 +109,25 @@ class CRM_Thinkific_Form_Settings extends CRM_Core_Form {
     return $elementNames;
   }
 
+  public function addRules(): void {
+    $this->addFormRule(['CRM_Thinkific_Form_Settings', 'formRule']);
+  }
+
+  /**
+   * @param array<string,string> $fields
+   *
+   * @return array<string,string>
+   */
+  public static function formRule(array $fields): array {
+    $messages = [];
+    if (str_contains($fields[SettingsManager::SUBDOMAIN], ' ')) {
+      $messages[SettingsManager::SUBDOMAIN] = CRM_Thinkific_ExtensionUtil::ts('Thinkific Sub domain cannot contain spaces.');
+    }
+    if (str_contains($fields[SettingsManager::API_KEY], ' ')) {
+      $messages[SettingsManager::API_KEY] = CRM_Thinkific_ExtensionUtil::ts('Thinkific Api Key cannot contain spaces.');
+    }
+
+    return $messages;
+  }
+
 }

--- a/tests/phpunit/Civi/Thinkific/Service/UserHandlerTest.php
+++ b/tests/phpunit/Civi/Thinkific/Service/UserHandlerTest.php
@@ -23,7 +23,14 @@ class UserHandlerTest extends BaseHeadlessTest {
         'POST',
         'users',
         [],
-        ['first_name' => $firstName, 'last_name' => $lastName, 'email' => $email, 'company' => '', 'external_source' => UserHandler::EXTERNAL_SOURCE_PREFIX . $contact['id']],
+        [
+          'first_name' => $firstName,
+          'last_name' => $lastName,
+          'email' => $email,
+          'company' => '',
+          'external_source' => UserHandler::EXTERNAL_SOURCE_PREFIX . $contact['id'],
+          'send_welcome_email' => TRUE,
+        ],
       )
       ->willReturn(new Response());
 


### PR DESCRIPTION
## Overview
Currently on the thinkific settings page if user inserts empty spaces then we accept it as valid value and try to make a connection to thinkific. This pR changes this behaviour and if there are spaces in the field then we return an error to the user that these fields cannot contain spaces.

## Before
![screen_recording_before](https://github.com/user-attachments/assets/b1518c2f-c75f-437d-844b-57a884744acd)


## After
![screen_recording_after](https://github.com/user-attachments/assets/c9b1c9ea-a8d0-44f6-8879-4204ff610bd9)

