### PR TITLE
DTAB-264: Remove Spaces From Course Field

### DIFF
--- a/js/modifyEventForm.js
+++ b/js/modifyEventForm.js
@@ -17,6 +17,7 @@ CRM.$(function ($) {
         observer.disconnect();
 
         toggleCustomGroupFields();
+        removeSpacesInCourseIdField();
         updatePlaceholder();
         $('.custom-group-Sync_Event_to_Thinkific input.crm-form-checkbox').on("change", function () {
           toggleCustomGroupFields();
@@ -77,6 +78,12 @@ CRM.$(function ($) {
       .attr('placeholder', ts('- All Statuses -')).crmSelect2({
       placeholder: '- All Statuses -',
       allowClear: true
+    });
+  }
+
+  function removeSpacesInCourseIdField() {
+    $('input[data-crm-custom="Sync_Event_to_Thinkific:Thinkific_Course_Id"]').on('input', function() {
+      this.value = this.value.replace(/\s/g, '');
     });
   }
 });


### PR DESCRIPTION
## Overview
Currently user can insert empty spaces in course id field and submit the event creation/updation form and it will be accepted as valid value. This PR changes this behaviour and does not allow the user to enter spaces in course id field.

## Before
![screen_recording_before](https://github.com/user-attachments/assets/ec748d68-f036-4ebf-b8d8-174a0bf87751)


## After
Nothing will happen if user tries to insert empty space as. all the spaces are removed from the fields as soon as the text of the field is changed.