### PR TITLE
COMCL-1447: Change Thinkific Authentication Mechanism

### DIFF
--- a/CRM/Thinkific/Form/Settings.php
+++ b/CRM/Thinkific/Form/Settings.php
@@ -12,9 +12,8 @@ use GuzzleHttp\Exception\BadResponseException;
 class CRM_Thinkific_Form_Settings extends CRM_Core_Form {
 
   public function buildQuickForm(): void {
-    CRM_Utils_System::setTitle(E::ts('Thinkfic LMS Settings'));
-    $this->add('password', SettingsManager::API_KEY, E::ts('Thinkific API key'), NULL, TRUE);
-    $this->add('text', SettingsManager::SUBDOMAIN, E::ts('Thinkific Sub domain'), NULL, TRUE);
+    CRM_Utils_System::setTitle(E::ts('Thinkific LMS Settings'));
+    $this->add('password', SettingsManager::API_ACCESS_TOKEN, E::ts('Thinkific Access Token'), NULL, TRUE);
 
     $this->addButtons([
       [
@@ -36,15 +35,13 @@ class CRM_Thinkific_Form_Settings extends CRM_Core_Form {
       /** @var Civi\Thinkific\Service\ApiClient $client */
       $client = Civi::service('service.thinkific.api_client');
       $headers = [
-        'X-Auth-API-Key' => $values[SettingsManager::API_KEY],
-        'X-Auth-Subdomain' => $values[SettingsManager::SUBDOMAIN],
+        'Authorization' => $values[SettingsManager::API_ACCESS_TOKEN] ? 'Bearer ' . $values[SettingsManager::API_ACCESS_TOKEN] : '',
         'Content-Type' => 'application/json',
       ];
       $client->request('GET', 'courses', $headers);
       /** @var array<string, mixed> $result */
       $result = civicrm_api3('Setting', 'create', [
-        SettingsManager::API_KEY => $values[SettingsManager::API_KEY],
-        SettingsManager::SUBDOMAIN => $values[SettingsManager::SUBDOMAIN],
+        SettingsManager::API_ACCESS_TOKEN => $values[SettingsManager::API_ACCESS_TOKEN],
       ]);
       if ($result['is_error'] == 0) {
         CRM_Core_Session::singleton()->setStatus(E::ts('Connection success.'), E::ts('Thinkfic Learning Management System Settings'), 'success');
@@ -78,7 +75,7 @@ class CRM_Thinkific_Form_Settings extends CRM_Core_Form {
     $domainId = CRM_Core_Config::domainID();
 
     /** @var array<string, array<int, array<string, mixed>>> $currentValues */
-    $currentValues = civicrm_api3('Setting', 'get', ['return' => [SettingsManager::API_KEY, SettingsManager::SUBDOMAIN]]);
+    $currentValues = civicrm_api3('Setting', 'get', ['return' => [SettingsManager::API_ACCESS_TOKEN]]);
 
     if (isset($currentValues['values'][$domainId])) {
       foreach ($currentValues['values'][$domainId] as $name => $value) {
@@ -122,11 +119,9 @@ class CRM_Thinkific_Form_Settings extends CRM_Core_Form {
    */
   public static function formRule(array $fields): array {
     $messages = [];
-    if (str_contains($fields[SettingsManager::SUBDOMAIN], ' ')) {
-      $messages[SettingsManager::SUBDOMAIN] = CRM_Thinkific_ExtensionUtil::ts('Thinkific Sub domain cannot contain spaces.');
-    }
-    if (str_contains($fields[SettingsManager::API_KEY], ' ')) {
-      $messages[SettingsManager::API_KEY] = CRM_Thinkific_ExtensionUtil::ts('Thinkific Api Key cannot contain spaces.');
+
+    if (str_contains($fields[SettingsManager::API_ACCESS_TOKEN], ' ')) {
+      $messages[SettingsManager::API_ACCESS_TOKEN] = CRM_Thinkific_ExtensionUtil::ts('Thinkific Access Token cannot contain spaces.');
     }
 
     return $messages;

--- a/Civi/Thinkific/Service/ApiClient.php
+++ b/Civi/Thinkific/Service/ApiClient.php
@@ -16,15 +16,11 @@ class ApiClient {
   private array $requestHeaders = [];
 
   public function __construct() {
-    /** @var array<int, array<string, mixed>> $settings */
-    $settings = civicrm_api4('Setting', 'get', [
-      'select' => [SettingsManager::API_KEY, SettingsManager::SUBDOMAIN],
-      'checkPermissions' => FALSE,
-    ])->getArrayCopy();
+    /** @var null|string $accessToken */
+    $accessToken = \Civi::settings()->get(SettingsManager::API_ACCESS_TOKEN);
 
     $this->requestHeaders = [
-      'X-Auth-API-Key' => $settings[0]['value'] ?? '',
-      'X-Auth-Subdomain' => $settings[1]['value'] ?? '',
+      'Authorization' => $accessToken ? 'Bearer ' . $accessToken : '',
       'Content-Type' => 'application/json',
     ];
   }

--- a/Civi/Thinkific/SettingsManager.php
+++ b/Civi/Thinkific/SettingsManager.php
@@ -2,15 +2,14 @@
 
 namespace Civi\Thinkific;
 
- /**
-  * Settings manager class to manage Thinkific settings.
-  */
+/**
+ * Settings manager class to manage Thinkific settings.
+ */
 class SettingsManager {
 
   /**
    * Constants for setting name
    */
-  const API_KEY = 'thinkific_api_key';
-  const SUBDOMAIN = 'thinkific_subdomain';
+  const API_ACCESS_TOKEN = 'thinkific_api_access_token';
 
 }

--- a/settings/Thinkific.setting.php
+++ b/settings/Thinkific.setting.php
@@ -15,26 +15,15 @@ use Civi\Thinkific\SettingsManager;
  * Settings metadata file
  */
 return [
-  'thinkific_api_key' => [
-    'name' => SettingsManager::API_KEY,
-    'title' => 'Thinkific Api Key',
+  SettingsManager::API_ACCESS_TOKEN => [
+    'name' => SettingsManager::API_ACCESS_TOKEN,
+    'title' => 'Thinkific Access Token',
     'type' => 'String',
     'html_type' => 'password',
     'default' => '',
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'Api key from Thinkific',
-    'html_attributes' => [],
-  ],
-  'thinkific_subdomain' => [
-    'name' => SettingsManager::SUBDOMAIN,
-    'title' => 'Thinkific Subdomain',
-    'type' => 'String',
-    'html_type' => 'text',
-    'default' => '',
-    'is_domain' => 1,
-    'is_contact' => 0,
-    'description' => 'Subdomain for Thinkific',
+    'description' => 'Access token from Thinkific',
     'html_attributes' => [],
   ],
 ];


### PR DESCRIPTION
## Overview
This PR changes the authentication mechanism to use api access token rather then api keys which has been deprecated by thinkific